### PR TITLE
POD cleanup

### DIFF
--- a/lib/Net/Jabber/Bot.pm
+++ b/lib/Net/Jabber/Bot.pm
@@ -1,7 +1,7 @@
 package Net::Jabber::Bot;
 
 use Moose;
-use MooseX::Types 
+use MooseX::Types
     -declare => [qw( JabberClientObject PosInt PosNum HundredInt )];
 
 # import builtin types
@@ -15,7 +15,7 @@ use Log::Log4perl qw(:easy);
 #use Data::Dumper; #For testing only.
 
 
-coerce Bool, from Str, 
+coerce Bool, from Str,
     via {($_ =~ m/(^on$)|(^true$)/i) + 0}; # True if it's on or true. Otherwise false.
 
 subtype JabberClientObject, as Object, where { $_->isa('Net::Jabber::Client') };
@@ -54,7 +54,6 @@ has 'from_full'           => (isa => Str, is => 'rw', default => sub{my $self = 
                                                                        $self->server .
                                                                        '/' .
                                                                        $self->alias});
-                                                                       
 
 has 'safety_mode'            => (isa => Bool, is => 'rw', default => 1, coerce => 1);
 has 'ignore_server_messages' => (isa => Bool, is => 'rw', default => 1, coerce => 1);
@@ -143,46 +142,46 @@ The object at present has the following enforced safeties as long as you do not 
 
 =item B<new>
 
-Minimal: 
+Minimal:
+
     my $bot = Net::Jabber::Bot->new(
-                                  server => 'host.domain.com' # Name of server when sending messages internally.
-                                , conference_server => 'conference.host.domain.com'
-                                , port => 522
-                                , username => 'username'
-                                , password => 'pasword'
-                                , safety_mode => 1
-                                , message_function => \&new_bot_message
-                                , background_function => \&background_checks
-                                , forums_and_responses => \%forum_list
-                            );
-    
+        server               => 'host.domain.com', # Name of server when sending messages internally.
+        conference_server    => 'conference.host.domain.com',
+        port                 => 522,
+        username             => 'username',
+        password             => 'pasword',
+        safety_mode          => 1,
+        message_function     => \&new_bot_message,
+        background_function  => \&background_checks,
+        forums_and_responses => \%forum_list
+    );
+
 All options:
+
     my $bot = Net::Jabber::Bot->new(
-                                  server => 'host.domain.com' # Name of server when sending messages internally.
-                                , conference_server => 'conference.host.domain.com'
-                                , server_host => 'talk.domain.com' # used to specify what jabber server to connect to on connect?
-                                , tls => 0 # set to 1 for google 
-                                , connection_type => 'tcpip'
-                                , port => 522
-                                , username => 'username'
-                                , password => 'pasword'
-                                , alias => 'cpan_bot'
-                                , message_function => \&new_bot_message
-                                , background_function => \&background_checks
-                                , loop_sleep_time => 15
-                                , process_timeout => 5
-                                , forums_and_responses => \%forum_list
-                                , ignore_server_messages => 1
-                                , ignore_self_messages => 1
-                                , out_messages_per_second => 4
-                                , max_message_size => 1000
-                                , max_messages_per_hour => 100
-                            );
+        server                  => 'host.domain.com', # Name of server when sending messages internally.
+        conference_server       => 'conference.host.domain.com',
+        server_host             => 'talk.domain.com', # used to specify what jabber server to connect to on connect?
+        tls                     => 0,                    # set to 1 for google
+        connection_type         => 'tcpip',
+        port                    => 522,
+        username                => 'username',
+        password                => 'pasword',
+        alias                   => 'cpan_bot',
+        message_function        => \&new_bot_message,
+        background_function     => \&background_checks,
+        loop_sleep_time         => 15,
+        process_timeout         => 5,
+        forums_and_responses    => \%forum_list,
+        ignore_server_messages  => 1,
+        ignore_self_messages    => 1,
+        out_messages_per_second => 4,
+        max_message_size        => 1000,
+        max_messages_per_hour   => 100
+    );
 
 
-
-
-Setup the object and connect to the server. Hash values are passed to new as a hash.
+Set up the object and connect to the server. Hash values are passed to new as a hash.
 
 The following initialization variables can be passed. Only marked variables are required (TODO)
 
@@ -201,7 +200,7 @@ Jabber server name
 =item B<server_host>
 
 Defaults to the same value set for 'server' above.
-This is where the bot initially connects. For google for instance, you should set this to 'gmail.com' 
+This is where the bot initially connects. For google for instance, you should set this to 'gmail.com'
 
 =item B<conference_server>
 
@@ -212,10 +211,12 @@ conferencee server (usually conference.$server_name)
 Defaults to 5222
 
 =item B<tls>
-Boolean value. defaults to 0. for google, it is know that this value must be 1 to work.  
+
+Boolean value. defaults to 0. for google, it is know that this value must be 1 to work.
 
 =item B<connection_type>
-defaults to 'tcpip' also takes 'http' 
+
+defaults to 'tcpip' also takes 'http'
 
 =item B<username>
 
@@ -236,9 +237,9 @@ The array is order sensitive and an empty string means it is going to respond to
 
 The found 'response string' is assumed to be at the beginning of the message. The message_funtion function will be called with the modified string.
 
-alias = jbot:, attention:
+    alias = jbot:, attention:
 
-    example1:
+example1:
 
     message: 'jbot: help'
 
@@ -475,10 +476,18 @@ sub Process { # Call connection process.
 =item B<Start>
 
 Primary subroutine save new called by the program. Does an endless loop of:
-1. Process
-2. If Process failed, Reconnect to server over larger and larger timeout
-3. run background process fed from new, telling it who I am and how many loops we have been through.
-4. Enforce a sleep to prevent server floods.
+
+=over
+
+=item 1. Process
+
+=item 2. If Process failed, Reconnect to server over larger and larger timeout
+
+=item 3. run background process fed from new, telling it who I am and how many loops we have been through.
+
+=item 4. Enforce a sleep to prevent server floods.
+
+=back
 
 =cut
 
@@ -499,7 +508,7 @@ sub Start {
         eval {$self->Process($process_timeout)};
 
         if($@) { #Assume the connection is down...
-	    ERROR("Server error: $@");
+            ERROR("Server error: $@");
             my $message = "Disconnected from " . $self->server . ":" . $self->port
                         . " as " . $self->username;
 
@@ -521,9 +530,10 @@ sub Start {
 
 You should not ever need to use this. the Start() kernel usually figures this out and calls it.
 
-Internal process
-1. Disconnects
-3. Re-initializes
+Internal process:
+
+    1. Disconnects
+    3. Re-initializes
 
 =cut
 
@@ -584,7 +594,7 @@ sub IsConnected {
 # TODO: ***NEED VERY GOOD DOCUMENTATION HERE*****
 =item B<_process_jabber_message> - DO NOT CALL
 
-Handles incoming messages.   
+Handles incoming messages.
 
 =cut
 
@@ -818,7 +828,6 @@ sub respond_to_self_messages {
 replys with number of messages sent so far this hour.
 
 =cut
-
 
 sub get_messages_this_hour {
     my $self = shift;


### PR DESCRIPTION
Changed the POD describing new() so that the code example would lay out properly.  Needed the blank paragraph between "minimal" and the code sample for POD to switch to verbatim mode.

Also removed some trailing spaces and a single indenting tab.
